### PR TITLE
Initial Design for Probes Repository

### DIFF
--- a/docs/REPOSITORY_DESIGN.md
+++ b/docs/REPOSITORY_DESIGN.md
@@ -19,20 +19,20 @@ Availability and latency/performance of the repository are not prioritised, prim
 To achieve the aforementioned goals, we can leverage Github Releases as our probe repository, serving compiled probes to consumers as downloadable release assets, enabling us to keep the entirety of the source-code, compilation process and hosting of probes consolidated together on a single, trusted and widely used platform. 
 
 Releases can be organised as follows:
-- Each new version of the Falco driver can be associated to a single github release, named to match the semver of the driver version.
+- Each new version of the Falco driver can be associated to a single github release, named to match the [name of the driver version](https://github.com/falcosecurity/test-infra/tree/master/driverkit/config).
 - Each compiled probe can be uploaded as an asset to the release of the driver version the probe was compiled against, named based on the runtime characteristics of the OS/kernel.
 
 E.g
 ```
-- 0.18.0
+- 17f5df52a7d9ed6bb12d3b1768460def8439936d
     - falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o
     - falco_amazonlinux2_4.14.225-169.362.amzn2.x86_64_1.o
     - falco_amazonlinux2_4.14.181-142.260.amzn2.x86_64_1.o
-- 0.17.1
+- 2aa88dcf6243982697811df4c1b484bcbe9488a2
     - falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o
     - falco_amazonlinux2_4.14.225-169.362.amzn2.x86_64_1.o
     - falco_amazonlinux2_4.14.181-142.260.amzn2.x86_64_1.o
-- 0.17.0
+- 5c0b863ddade7a45568c0ac97d037422c9efb750
     - falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o
     - falco_amazonlinux2_4.14.225-169.362.amzn2.x86_64_1.o
     - falco_amazonlinux2_4.14.181-142.260.amzn2.x86_64_1.o
@@ -43,7 +43,7 @@ To download a particular probe based on the driver version/OS/kernel version, yo
 `https://github.com/thought-machine/falco-probes/releases/download/$DRIVER_VERSION/$PROBE_FILENAME.o`.
 
 For example, to download the first probe listed above via curl you would simply need to:
-`curl -L https://github.com/thought-machine/falco-probes/releases/download/0.18.0/falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o > falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o`
+`curl -L https://github.com/thought-machine/falco-probes/releases/download/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o > falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o`
 
 As new OS/kernel version combinations become available, all prior releases can be updated in parallel to include assets for each newly compiled probe. 
 


### PR DESCRIPTION
Initial draft of the repository design document.

Relies heavily on the approach detailed in #1 , and is light on detail regard the parameterisation/triggering of probe compilation jobs, instead focusing only on the upload mechanism and storage approach.