### PR TITLE
Add //cmd/list-kernel-packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 plz-out
 .plzconfig.local
 dist/
+*.txt

--- a/cmd/list-kernel-packages/BUILD
+++ b/cmd/list-kernel-packages/BUILD
@@ -1,0 +1,11 @@
+go_binary(
+    name = "list-kernel-packages",
+    srcs = ["main.go"],
+    deps = [
+        "//internal/cmd",
+        "//internal/logging",
+        "//pkg/docker",
+        "//pkg/operatingsystem",
+        "//pkg/operatingsystem/resolver",
+    ],
+)

--- a/cmd/list-kernel-packages/main.go
+++ b/cmd/list-kernel-packages/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/thought-machine/falco-probes/internal/cmd"
+	"github.com/thought-machine/falco-probes/internal/logging"
+	"github.com/thought-machine/falco-probes/pkg/docker"
+	"github.com/thought-machine/falco-probes/pkg/operatingsystem/resolver"
+)
+
+type opts struct {
+	OutFile    string `long:"out_file" description:"The path to a file to output a list of Falco probes too (default: output to stdout)"`
+	Positional struct {
+		OperatingSystem string `positional-arg-name:"operating_system"`
+	} `positional-args:"yes" required:"true"`
+}
+
+var log = logging.Logger
+
+func main() {
+	opts := &opts{}
+	cmd.MustParseFlags(opts)
+
+	cli := docker.MustClient()
+
+	log.Info().
+		Str("operating_system", opts.Positional.OperatingSystem).
+		Msg("Resolving operating system")
+	operatingSystem, err := resolver.OperatingSystem(cli, opts.Positional.OperatingSystem)
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not get operating system")
+	}
+
+	log.Info().
+		Str("operating_system", opts.Positional.OperatingSystem).
+		Msg("Getting kernel package names")
+	kernelPackageNames, err := operatingSystem.GetKernelPackageNames()
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not kernel package names")
+	}
+
+	log.Info().
+		Int("amount", len(kernelPackageNames)).
+		Str("operating_system", opts.Positional.OperatingSystem).
+		Msg("got kernel packages")
+
+	output := strings.Join(kernelPackageNames, "\n")
+
+	if len(opts.OutFile) > 0 {
+		ioutil.WriteFile(opts.OutFile, []byte(output), 0644)
+		log.Info().
+			Str("path", opts.OutFile).
+			Msg("wrote kernel package names to file")
+
+		return
+	}
+
+	fmt.Println(output)
+}


### PR DESCRIPTION
This PR adds a `//cmd/list-kernel-packages` go_binary which can be run via `plz run //cmd/list-kernel-package -- <flags> <operating-system>`, e.g.

```bash
$ plz run //cmd/list-kernel-packages -- --verbose amazonlinux2
# outputs list to stdout

$ plz run //cmd/list-kernel-packages -- --verbose amazonlinux2 --out_file amazonlinux2_kernel_packages.txt
# outputs list to file
```

Currently comparing against the `build-falco-ebpf-probe` branch as this PR is depends on #7, will update once that is merged.