### PR TITLE
Add publishing of built Falco eBPF probes to GitHub releases

### DIFF
--- a/.github/workflows/build-and-publish-probes.yaml
+++ b/.github/workflows/build-and-publish-probes.yaml
@@ -1,4 +1,4 @@
-name: build-probes
+name: build-and-publish-probes
 on: [push]
 jobs:
   generate-jobs:
@@ -11,7 +11,7 @@ jobs:
     outputs:
       operating-systems: ${{ steps.set-operating-systems.outputs.operating-systems }}
 
-  build-probes:
+  build-and-publish-probes:
     needs: generate-jobs
     runs-on: ubuntu-latest
     strategy:
@@ -19,4 +19,6 @@ jobs:
         operating-system: ${{ fromJson(needs.generate-jobs.outputs.operating-systems) }}
     steps:
       - uses: actions/checkout@v2
-      - run: ./pleasew run //build/github/build-probes-for-operating-system -- ${{ matrix.operating-system }}
+      - run: ./pleasew run //build/github/build-and-publish-probes-for-operating-system -- ${{ matrix.operating-system }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/github/build-and-publish-probes-for-operating-system/BUILD
+++ b/build/github/build-and-publish-probes-for-operating-system/BUILD
@@ -1,5 +1,5 @@
 go_binary(
-    name = "build-probes-for-operating-system",
+    name = "build-and-publish-probes-for-operating-system",
     srcs = ["main.go"],
     deps = [
         "//internal/cmd",
@@ -8,5 +8,7 @@ go_binary(
         "//pkg/falcodriverbuilder",
         "//pkg/operatingsystem",
         "//pkg/operatingsystem/resolver",
+        "//pkg/repository",
+        "//pkg/repository/ghreleases",
     ],
 )

--- a/cmd/build-falco-ebpf-probe/main.go
+++ b/cmd/build-falco-ebpf-probe/main.go
@@ -37,7 +37,7 @@ func main() {
 		log.Fatal().Err(err).Msg("could not get kernel package")
 	}
 
-	if err := falcodriverbuilder.BuildEBPFProbe(
+	if _, _, err := falcodriverbuilder.BuildEBPFProbe(
 		cli,
 		opts.FalcoVersion,
 		operatingSystem,

--- a/docs/REPOSITORY_DESIGN.md
+++ b/docs/REPOSITORY_DESIGN.md
@@ -19,20 +19,20 @@ Availability and latency/performance of the repository are not prioritised, prim
 To achieve the aforementioned goals, we can leverage Github Releases as our probe repository, serving compiled probes to consumers as downloadable release assets, enabling us to keep the entirety of the source-code, compilation process and hosting of probes consolidated together on a single, trusted and widely used platform. 
 
 Releases can be organised as follows:
-- Each new version of the Falco driver can be associated to a single github release, named to match the [name of the driver version](https://github.com/falcosecurity/test-infra/tree/master/driverkit/config).
+- Each new version of the Falco driver can be associated to a single github release, named to match the [name of the driver version](https://github.com/falcosecurity/test-infra/tree/master/driverkit/config). This is truncated to 8 characters in order to meet GitHub's tag length limitations.
 - Each compiled probe can be uploaded as an asset to the release of the driver version the probe was compiled against, named based on the runtime characteristics of the OS/kernel.
 
 E.g
 ```
-- 17f5df52a7d9ed6bb12d3b1768460def8439936d
+- 17f5df52 (17f5df52a7d9ed6bb12d3b1768460def8439936d)
     - falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o
     - falco_amazonlinux2_4.14.225-169.362.amzn2.x86_64_1.o
     - falco_amazonlinux2_4.14.181-142.260.amzn2.x86_64_1.o
-- 2aa88dcf6243982697811df4c1b484bcbe9488a2
+- 2aa88dcf (2aa88dcf6243982697811df4c1b484bcbe9488a2)
     - falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o
     - falco_amazonlinux2_4.14.225-169.362.amzn2.x86_64_1.o
     - falco_amazonlinux2_4.14.181-142.260.amzn2.x86_64_1.o
-- 5c0b863ddade7a45568c0ac97d037422c9efb750
+- 5c0b863d (5c0b863ddade7a45568c0ac97d037422c9efb750)
     - falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o
     - falco_amazonlinux2_4.14.225-169.362.amzn2.x86_64_1.o
     - falco_amazonlinux2_4.14.181-142.260.amzn2.x86_64_1.o
@@ -40,10 +40,10 @@ E.g
 ```
 
 To download a particular probe based on the driver version/OS/kernel version, you would use the following URL
-`https://github.com/thought-machine/falco-probes/releases/download/$DRIVER_VERSION/$PROBE_FILENAME.o`.
+`https://github.com/thought-machine/falco-probes/releases/download/$FIRST_8_CHARACTERS_OF_DRIVER_VERSION/$PROBE_FILENAME.o`.
 
 For example, to download the first probe listed above via curl you would simply need to:
-`curl -L https://github.com/thought-machine/falco-probes/releases/download/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o > falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o`
+`curl -L https://github.com/thought-machine/falco-probes/releases/download/17f5df52/falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o > falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o`
 
 As new OS/kernel version combinations become available, all prior releases can be updated in parallel to include assets for each newly compiled probe. 
 
@@ -77,6 +77,12 @@ With any stored asset, a digest should be produced to enable consumers to verify
 ## Limits or Restrictions on Releases
 
 The only documented constraint associated with releases is a [max file-size constraint of 2GB](https://docs.github.com/en/github/administering-a-repository/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas). Since we will be producing large releases, and editing individual releases multiple times, we've [deployed a crack team of hamsters to stress-test releases](https://github.com/sHesl/release-loop/actions) by continually updating an existing release with new assets. If there are any undocumented restrictions around the number of edits you can apply to a release, or the number of files associated to a single release, they will find it!
+
+During the implementation of this, we discovered a limitation on GitHub tags where tags cannot be 40 characters in length:
+```
+422 Validation Failed [{Resource:Release Field:pre_receive Code:custom Message:pre_receive Sorry, branch or tag names consisting of 40 hex characters are not allowed.} {Resource:Release Field: Code:custom Message:Published releases must have a valid tag}]
+```
+To work around this we have truncated the originally proposed tag to 8 characters.
 
 ## Future Considerations
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/grpc v1.39.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github/v37 v37.0.0 h1:rCspN8/6kB1BAJWZfuafvHhyfIo5fkAulaP/3bOQ/tM=
 github.com/google/go-github/v37 v37.0.0/go.mod h1:LM7in3NmXDrX58GbEHy7FtNLbI2JijX93RnMKvWG3m4=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
@@ -834,6 +834,7 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
+google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/cloud v0.0.0-20151119220103-975617b05ea8/go.mod h1:0H1ncTHf11KCFhTc/+EFRbzSCOZx+VUbRMk55Yv5MYk=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -1,9 +1,8 @@
 package cmd
 
 import (
-	"log"
 	"os"
-	"path/filepath"
+	"path"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/thought-machine/falco-probes/internal/logging"
@@ -11,11 +10,16 @@ import (
 
 // MustParseFlags parses the given application options from command line arguments.
 func MustParseFlags(opts interface{}) {
-	flagParser := flags.NewNamedParser(filepath.Base(os.Args[0]), flags.Default)
+	appName := path.Base(os.Args[0])
+	flagParser := flags.NewNamedParser(appName, flags.Default)
+
+	flagParser.EnvNamespaceDelimiter = "_"
+	flagParser.NamespaceDelimiter = "_"
 
 	loggingOpts := &LoggingOpts{}
 	flagParser.AddGroup("logging options", "logging options", loggingOpts)
-	flagParser.AddGroup("application options", "application options", opts)
+
+	flagParser.AddGroup(appName+" options", "", opts)
 
 	args, err := flagParser.Parse()
 
@@ -23,7 +27,7 @@ func MustParseFlags(opts interface{}) {
 		if flagsErr, ok := err.(*flags.Error); ok {
 			handleFlagsErr(flagsErr)
 		}
-		log.Fatal(err)
+		logging.Logger.Fatal().Err(err).Msg("could not parse flags")
 	}
 
 	if len(args) > 0 {

--- a/pkg/repository/BUILD
+++ b/pkg/repository/BUILD
@@ -2,6 +2,7 @@ go_library(
     name = "repository",
     srcs = ["repository.go"],
     visibility = [
+        "//build/...",
         "//pkg/repository/...",
     ],
 )

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -2,8 +2,8 @@ package repository
 
 // Repository abstracts the implementation of repositories which mirror Falco probes.
 type Repository interface {
-	// PublishProbe "publishes" (uploads/mirrors) the given probePath to the repository using the given driverVersion and probeName to organise probes.
-	PublishProbe(driverVersion string, probeName string, probePath string) error
+	// PublishProbe "publishes" (uploads/mirrors) the given probePath to the repository using the given driverVersion and probePath to organise probes.
+	PublishProbe(driverVersion string, probePath string) error
 	// IsAlreadyMirrored returns whether or not the given probeName is already mirrored in the repository for the given driverVersion.
 	IsAlreadyMirrored(driverVersion string, probeName string) bool
 }


### PR DESCRIPTION
This PR adds the uploading of built Falco eBPF probes to GitHub Releases. 

We've used Go to do this as we needed the driverVersion information and it fits quite well into our parallel building in Go too in `build/build-and-publish-probes-for-operating-system` and the GitHub API was made easy via the https://pkg.go.dev/github.com/google/go-github/v37/github library.

We've had to modify the repository design slightly as GitHub doesn't support tags that are 40 characters long. To work around this limitation, I've truncated the driver version to 8 characters, which still meets our design goals (🤞 for no collisions).

We're also only logging out any upload errors for the time being as we have not yet implemented the `IsAlreadyMirrored` function because we are seeing "already exists" errors.