### PR TITLE
Refactor parallel running to be testable and add tests

### DIFF
--- a/internal/cmd/BUILD
+++ b/internal/cmd/BUILD
@@ -3,6 +3,7 @@ go_library(
     srcs = [
         "flags.go",
         "logging.go",
+        "parallel.go",
     ],
     visibility = [
         "//build/...",
@@ -12,5 +13,17 @@ go_library(
         "//internal/logging",
         "//third_party/go:jessevdk_flags",
         "//third_party/go:rs_zerolog",
+    ],
+)
+
+go_test(
+    name = "cmd_test",
+    srcs = [
+        "parallel_test.go",
+    ],
+    external = True,
+    deps = [
+        ":cmd",
+        "//third_party/go:stretchr_testify",
     ],
 )

--- a/internal/cmd/parallel.go
+++ b/internal/cmd/parallel.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"sync"
+)
+
+// RunParallelAndCollectErrors runs the given list of functions in parallel with the given parallel limits and returns the errors.
+// this is is similar to https://pkg.go.dev/golang.org/x/sync/errgroup#Group.Wait, but returns all of the encountered errors instead of just one.
+func RunParallelAndCollectErrors(fns []func() error, limit int) []error {
+	limiter := make(chan struct{}, limit)
+	var wg sync.WaitGroup
+	// errChan to collect errors from all the goroutines.
+	errChan := make(chan error, len(fns))
+
+	for _, fn := range fns {
+		fn := fn
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			limiter <- struct{}{}
+			defer func() { <-limiter }()
+			errChan <- fn()
+		}()
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	errs := []error{}
+
+	for err := range errChan {
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errs
+}

--- a/internal/cmd/parallel_test.go
+++ b/internal/cmd/parallel_test.go
@@ -1,0 +1,63 @@
+package cmd_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thought-machine/falco-probes/internal/cmd"
+)
+
+func TestRunParallelAndCollectErrors(t *testing.T) {
+	var tests = []struct {
+		description string
+		inFnReturns []error
+		inLimit     int
+		outErrs     []error
+	}{
+		{
+			"no errors",
+			[]error{nil, nil, nil, nil},
+			3,
+			[]error{},
+		},
+		{
+			"1 error",
+			[]error{nil, nil, fmt.Errorf("foo"), nil},
+			3,
+			[]error{fmt.Errorf("foo")},
+		},
+		{
+			"2 errors",
+			[]error{nil, fmt.Errorf("bar"), fmt.Errorf("foo"), nil},
+			3,
+			[]error{fmt.Errorf("bar"), fmt.Errorf("foo")},
+		},
+		{
+			"all errors",
+			[]error{fmt.Errorf("bar"), fmt.Errorf("bar"), fmt.Errorf("foo"), fmt.Errorf("bar")},
+			3,
+			[]error{fmt.Errorf("bar"), fmt.Errorf("bar"), fmt.Errorf("foo"), fmt.Errorf("bar")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			inFns := []func() error{}
+			for _, fnRes := range tt.inFnReturns {
+				fnRes := fnRes // t.Run introduces concurrency
+				inFns = append(inFns, func() error {
+					return fnRes
+				})
+			}
+
+			resErrs := cmd.RunParallelAndCollectErrors(inFns, tt.inLimit)
+			// As we're running fns in parallel, there's no guarantees on the order of which they return
+			// so we're checking that the length is what we expect and asserting whether everything we want is in the returned errs.
+			assert.Len(t, resErrs, len(tt.outErrs))
+			for _, fnRes := range tt.outErrs {
+				assert.Contains(t, resErrs, fnRes)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We currently have a bug in our `//build/github/build-and-publish-probes-for-operating-system` where it seems like we're fatally exiting when there are no errors returned. 
This PR fixes the logging of errors, so when they occur again (they seem to happen quite frequently) we'll have some more useful data to understand why the build failed. It also gives us confidence that the error is not a result of our parallel running code which is now unit tested