### PR TITLE
Reuse falco-driver-loader script from 0.28.1 for all Falco versions

### DIFF
--- a/build/github/build-and-publish-probes-for-operating-system/main.go
+++ b/build/github/build-and-publish-probes-for-operating-system/main.go
@@ -20,9 +20,9 @@ var log = logging.Logger
 // Note: We can only support 0.28.1+ at the moment as it seems like the falco-driver-loader script changed in an incompatible way between 0.26 and 0.28.1.
 // TODO: To fix this, we could just source the driver loader script from 0.28.1 and reuse that instead of the script bundled w/ each falco-driver-loader.
 var FalcoVersions = []string{
-	// "0.24.0", // falco-driver-version: 85c88952b018fdbce2464222c3303229f5bfcfad
-	// "0.25.0", // falco-driver-version: ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7
-	// "0.26.0", // falco-driver-version: 2aa88dcf6243982697811df4c1b484bcbe9488a2
+	"0.24.0", // falco-driver-version: 85c88952b018fdbce2464222c3303229f5bfcfad
+	"0.25.0", // falco-driver-version: ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7
+	"0.26.0", // falco-driver-version: 2aa88dcf6243982697811df4c1b484bcbe9488a2
 	"0.28.1", // falco-driver-version: 5c0b863ddade7a45568c0ac97d037422c9efb750
 	"0.29.1", // falco-driver-version: 17f5df52a7d9ed6bb12d3b1768460def8439936d
 }

--- a/pkg/falcodriverbuilder/BUILD
+++ b/pkg/falcodriverbuilder/BUILD
@@ -20,12 +20,14 @@ go_test(
     name = "falcodriverbuilder_test",
     size = "large",
     srcs = [
+        "build-ebpf-probe_test.go",
         "falcodriverbuilder_test.go",
     ],
     external = True,
     deps = [
         ":falcodriverbuilder",
         "//pkg/docker",
+        "//pkg/operatingsystem/resolver",
         "//third_party/go:stretchr_testify",
     ],
 )

--- a/pkg/falcodriverbuilder/build-ebpf-probe.go
+++ b/pkg/falcodriverbuilder/build-ebpf-probe.go
@@ -10,7 +10,7 @@ import (
 
 var log = logging.Logger
 
-// BuildEBPFProbe builds a Falco eBPF probe with the given falcoVersion, operatingsystem and kernelPackageName, returning the falcoDriverVersio and outProbePath.
+// BuildEBPFProbe builds a Falco eBPF probe with the given falcoVersion, operatingsystem and kernelPackageName, returning the falcoDriverVersio, and outProbePath.
 func BuildEBPFProbe(
 	cli *docker.Client,
 	falcoVersion string,

--- a/pkg/falcodriverbuilder/build-ebpf-probe.go
+++ b/pkg/falcodriverbuilder/build-ebpf-probe.go
@@ -10,7 +10,7 @@ import (
 
 var log = logging.Logger
 
-// BuildEBPFProbe builds a Falco eBPF probe with the given falcoVersion, operatingsystem and kernelPackageName, returning the falcoDriverVersio, and outProbePath.
+// BuildEBPFProbe builds a Falco eBPF probe with the given falcoVersion, operatingsystem and kernelPackageName, returning the falcoDriverVersion and outProbePath.
 func BuildEBPFProbe(
 	cli *docker.Client,
 	falcoVersion string,

--- a/pkg/falcodriverbuilder/build-ebpf-probe_test.go
+++ b/pkg/falcodriverbuilder/build-ebpf-probe_test.go
@@ -1,0 +1,47 @@
+package falcodriverbuilder_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thought-machine/falco-probes/pkg/docker"
+	"github.com/thought-machine/falco-probes/pkg/falcodriverbuilder"
+	"github.com/thought-machine/falco-probes/pkg/operatingsystem/resolver"
+)
+
+func TestBuildEBPFProbe(t *testing.T) {
+	var tests = []struct {
+		falcoVersion        string
+		operatingSystemName string
+		kernelPackageName   string
+	}{
+		{"0.29.1", "amazonlinux2", "4.14.200-155.322.amzn2"},
+		{"0.29.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
+		{"0.28.1", "amazonlinux2", "4.14.200-155.322.amzn2"},
+		{"0.28.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
+		{"0.27.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
+		{"0.26.2", "amazonlinux2", "4.14.200-155.322.amzn2"},
+		{"0.26.1", "amazonlinux2", "4.14.200-155.322.amzn2"},
+		{"0.26.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
+		{"0.25.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
+		{"0.24.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
+	}
+
+	cli := docker.MustClient()
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("%s-%s-%s", tt.falcoVersion, tt.operatingSystemName, tt.kernelPackageName), func(t *testing.T) {
+			t.Parallel()
+			operatingSystem, err := resolver.OperatingSystem(cli, tt.operatingSystemName)
+			require.NoError(t, err)
+			kernelPackage, err := operatingSystem.GetKernelPackageByName(tt.kernelPackageName)
+			require.NoError(t, err)
+			_, _, err = falcodriverbuilder.BuildEBPFProbe(cli, tt.falcoVersion, operatingSystem, kernelPackage)
+			assert.NoError(t, err)
+		})
+
+	}
+}

--- a/pkg/falcodriverbuilder/falco-driver-builder.Dockerfile
+++ b/pkg/falcodriverbuilder/falco-driver-builder.Dockerfile
@@ -1,4 +1,4 @@
-ARG FALCO_VERSION=0.28.1
+ARG FALCO_VERSION
 FROM "docker.io/falcosecurity/falco-driver-loader:${FALCO_VERSION}"
 
 ENV FALCO_DRIVER_LOADER_PATH="/usr/bin/falco-driver-loader"
@@ -6,19 +6,38 @@ ENV FALCO_DRIVER_LOADER_PATH="/usr/bin/falco-driver-loader"
 SHELL ["/bin/bash", "-c"]
 
 RUN set -Eeuxo pipefail; \
+    # Determine DRIVERS_REPO, DRIVER_VERSION, DRIVER_NAME from existing falco-driver-loader to persist them in the 0.28.1 falco-driver-loader script.
+    export DRIVERS_REPO=$(grep ^DRIVERS_REPO "${FALCO_DRIVER_LOADER_PATH}" | cut -f2 -d\") && \
+    export DRIVER_VERSION=$(grep ^DRIVER_VERSION "${FALCO_DRIVER_LOADER_PATH}" | cut -f2 -d\") && \
+    export DRIVER_NAME=$(grep ^DRIVER_NAME "${FALCO_DRIVER_LOADER_PATH}" | cut -f2 -d\") && \
+    # Use falco-driver-loader from 0.28.1 (the patches below work with that script.)
+    curl -L https://raw.githubusercontent.com/falcosecurity/falco/0.28.1/scripts/falco-driver-loader \
+    -o /usr/bin/falco-driver-loader && chmod +x /usr/bin/falco-driver-loader && \
+    # Set DRIVERS_REPO to match existing falco-driver-loader script.
+    sed -i '/^\s*DRIVERS_REPO=/d' "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i "2 i DRIVERS_REPO=\"${DRIVERS_REPO}\"" "${FALCO_DRIVER_LOADER_PATH}" && \
+    # Set DRIVER_VERSION to match existing falco-driver-loader script.
+    sed -i '/^\s*DRIVER_VERSION=/d' "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i "2 i DRIVER_VERSION=\"${DRIVER_VERSION}\"" "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i '3 i echo "DRIVER_VERSION: $DRIVER_VERSION"' "${FALCO_DRIVER_LOADER_PATH}" && \
+    # Set DRIVER_NAME to match existing falco-driver-loader script.
+    sed -i '/^\s*DRIVER_NAME=/d' "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i "2 i DRIVER_NAME=\"${DRIVER_NAME}\"" "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i '3 i echo "DRIVER_NAME: $DRIVER_NAME"' "${FALCO_DRIVER_LOADER_PATH}" && \
+    # Set FALCO_VERSION to match existing falco-driver-loader script.
+    sed -i '/^\s*FALCO_VERSION=/d' "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i "2 i FALCO_VERSION=\"${FALCO_VERSION}\"" "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i '3 i echo "FALCO_VERSION: $FALCO_VERSION"' "${FALCO_DRIVER_LOADER_PATH}" && \
     # Disable downloading from Falco driver repository.
-    sed -i 's/ENABLE_DOWNLOAD=.*/ENABLE_DOWNLOAD=""/g' "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i '/^\s*ENABLE_DOWNLOAD=/d' "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i '2 i ENABLE_DOWNLOAD=""' "${FALCO_DRIVER_LOADER_PATH}" && \
     # Enable compilation of eBPF driver.
     sed -i 's/ENABLE_COMPILE=.*/ENABLE_COMPILE="yes"/g' "${FALCO_DRIVER_LOADER_PATH}" && \
     sed -i 's/DRIVER=.*/DRIVER="bpf"/g' "${FALCO_DRIVER_LOADER_PATH}" && \
-    # Echo the KERNEL_RELEASE, KERNEL_VERSION and ARCH
-    sed -i -e '/^KERNEL_RELEASE=.*/a\' -e 'echo "KERNEL_RELEASE: $KERNEL_RELEASE"' "${FALCO_DRIVER_LOADER_PATH}" && \
-    sed -i -e '/^KERNEL_VERSION=.*/a\' -e 'echo "KERNEL_VERSION: $KERNEL_VERSION"' "${FALCO_DRIVER_LOADER_PATH}" && \
-    sed -i -e '/^ARCH=.*/a\' -e 'echo "ARCH: $ARCH"' "${FALCO_DRIVER_LOADER_PATH}" && \
     # Set the KERNELDIR from the KERNEL_RELEASE. This is used in kernel Makefiles.
     sed -i -e '/^KERNEL_RELEASE=.*/a\' -e 'export KERNELDIR="/lib/modules/$KERNEL_RELEASE/build"' "${FALCO_DRIVER_LOADER_PATH}" && \
     # Allow setting the outputs of `uname` via UNAME_* environment variables.
-    sed -i 's/uname -r/echo "${UNAME_R:-$(uname -r)}"/g' "${FALCO_DRIVER_LOADER_PATH}" && \
-    sed -i 's/uname -v/echo "${UNAME_V:-$(uname -v)}"/g' "${FALCO_DRIVER_LOADER_PATH}" && \
-    sed -i 's/uname -m/echo "${UNAME_M:-$(uname -m)}"/g' "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i 's/uname -r/echo "${UNAME_R}"/g' "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i 's/uname -v/echo "${UNAME_V}"/g' "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i 's/uname -m/echo "${UNAME_M}"/g' "${FALCO_DRIVER_LOADER_PATH}" && \
     echo "Done!"

--- a/pkg/operatingsystem/resolver/BUILD
+++ b/pkg/operatingsystem/resolver/BUILD
@@ -4,6 +4,7 @@ go_library(
     visibility = [
         "//build/...",
         "//cmd/...",
+        "//pkg/...",
     ],
     deps = [
         "//pkg/docker",


### PR DESCRIPTION
This PR re-uses the `falco-driver-loader` script from Falco 0.28.1, whilst maintaining the hardcoded  `DRIVERS_REPO`, `DRIVER_VERSION` and `DRIVER_NAME` values from the original script shipped w/ other Falco versions. 

This is needed so that we can build probes for other versions of Falco where the falco-driver-loader script is different as the `sed` patches we have written only work against the script at Falco 0.28.1.

This closes #20 and potentially closes #27 (time will tell). 
