### PR TITLE
Fix build loop goroutine gotcha

### DIFF
--- a/build/github/build-and-publish-probes-for-operating-system/main.go
+++ b/build/github/build-and-publish-probes-for-operating-system/main.go
@@ -17,8 +17,6 @@ var log = logging.Logger
 
 // FalcoVersionNames represents the list of Falco versions to build eBPF probes for the given operating system. We're only interested in building the versions
 // that diversify our support for Falco driver versions as they maintain compatibility between different Falco versions.
-// Note: We can only support 0.28.1+ at the moment as it seems like the falco-driver-loader script changed in an incompatible way between 0.26 and 0.28.1.
-// TODO: To fix this, we could just source the driver loader script from 0.28.1 and reuse that instead of the script bundled w/ each falco-driver-loader.
 var FalcoVersionNames = []string{
 	"0.24.0", // falco-driver-version: 85c88952b018fdbce2464222c3303229f5bfcfad
 	"0.25.0", // falco-driver-version: ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7
@@ -78,6 +76,9 @@ func main() {
 
 	parallelFns := []func() error{}
 	for _, kernelPackageName := range kernelPackageNames {
+		// https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		kernelPackageName := kernelPackageName
+
 		parallelFns = append(parallelFns, func() error {
 			return process1KernelPackage(
 				cli,

--- a/internal/cmd/parallel.go
+++ b/internal/cmd/parallel.go
@@ -6,6 +6,7 @@ import (
 
 // RunParallelAndCollectErrors runs the given list of functions in parallel with the given parallel limits and returns the errors.
 // this is is similar to https://pkg.go.dev/golang.org/x/sync/errgroup#Group.Wait, but returns all of the encountered errors instead of just one.
+// Note: Beware of https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
 func RunParallelAndCollectErrors(fns []func() error, limit int) []error {
 	limiter := make(chan struct{}, limit)
 	var wg sync.WaitGroup

--- a/pkg/docker/logs_test.go
+++ b/pkg/docker/logs_test.go
@@ -12,7 +12,7 @@ func TestDockerRunLogs(t *testing.T) {
 	cli := docker.MustClient()
 
 	out, err := cli.Run(&docker.RunOpts{
-		Image: "docker.io/library/alpine:3.14",
+		Image: "docker.io/library/alpine:3.14@sha256:1775bebec23e1f3ce486989bfc9ff3c4e951690df84aa9f926497d82f2ffca9d",
 		Cmd:   []string{"cat", "/etc/os-release"},
 	})
 


### PR DESCRIPTION
Fixes #34 

Annoyingly, a bit hard to unit test the logic as most of it is living in the `main.go`. 

To solve this in a better way; we can refactor the parallel implementation to use a job queue with workers that pick job configuration off from a channel. I've created #35 to capture this