### PR TITLE
Skip previously compiled kernel package by checking github releases via API

### DIFF
--- a/.github/workflows/build-and-publish-probes.yaml
+++ b/.github/workflows/build-and-publish-probes.yaml
@@ -5,7 +5,6 @@ on:
       - master
   schedule:
     - cron:  '0 0 * * *' # Runs at 00:00 UTC every day.
-  workflow_dispatch:
 jobs:
   generate-jobs:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-publish-probes.yaml
+++ b/.github/workflows/build-and-publish-probes.yaml
@@ -5,6 +5,7 @@ on:
       - master
   schedule:
     - cron:  '0 0 * * *' # Runs at 00:00 UTC every day.
+  workflow_dispatch:
 jobs:
   generate-jobs:
     runs-on: ubuntu-latest

--- a/build/github/build-and-publish-probes-for-operating-system/BUILD
+++ b/build/github/build-and-publish-probes-for-operating-system/BUILD
@@ -10,5 +10,6 @@ go_binary(
         "//pkg/operatingsystem/resolver",
         "//pkg/repository",
         "//pkg/repository/ghreleases",
+        "//third_party/go:google_github",
     ],
 )

--- a/build/github/build-and-publish-probes-for-operating-system/main.go
+++ b/build/github/build-and-publish-probes-for-operating-system/main.go
@@ -93,7 +93,6 @@ func main() {
 		if falcoVersionHasRelease(releases, FalcoVersions) && kernelPackageHasBeenCompiled(releases, kernelPackageName) {
 			log.Info().
 				Str("kernel_package_name", kernelPackageName).
-				Int("falco_driver_versions", len(FalcoVersions)).
 				Msg("Skipping, kernel package has already been compiled against all supported falco driver versions")
 
 			continue

--- a/pkg/repository/ghreleases/ghreleases.go
+++ b/pkg/repository/ghreleases/ghreleases.go
@@ -87,6 +87,16 @@ func (ghr *GHReleases) IsAlreadyMirrored(driverVersion string, probeName string)
 	return true, nil
 }
 
+// GetReleases uses the github API to list all previous releases
+func (ghr *GHReleases) GetReleases() ([]*github.RepositoryRelease, error) {
+	releases, err := ghr.ghClient.ListReleases()
+	if err != nil {
+		return nil, fmt.Errorf("could not list releases: %w", err)
+	}
+
+	return releases, nil
+}
+
 // getAssetFromReleaseByName uses the github API to identify whether the desired probe is an asset of the given release
 func (ghr *GHReleases) getAssetFromReleaseByName(release *github.RepositoryRelease, probeName string) (*github.ReleaseAsset, error) {
 


### PR DESCRIPTION
While looking into #15, I noticed the [ListRelease](https://docs.github.com/en/rest/reference/repos#list-releases) endpoint of the github releases API returns each release with an _unpaginated_ list of all the assets in each release. The number of releases is paginated (default is 30, max 100), but the asset list isn't (for example, [this release](https://github.com/sHesl/release-loop/releases/tag/loop) returned all 10k assets w/names).

We could use this list to cross-reference for previously compiled probes, needing just 1 github API request to do so.

[Example](https://github.com/sHesl/falco-probes/runs/3329578618?check_suite_focus=true#step:3:27) run.