### PR TITLE
enable extra amzn2 kernels for kernel-ng kernel-5.4

### DIFF
--- a/pkg/falcodriverbuilder/build-ebpf-probe_test.go
+++ b/pkg/falcodriverbuilder/build-ebpf-probe_test.go
@@ -27,6 +27,12 @@ func TestBuildEBPFProbe(t *testing.T) {
 		{"0.26.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
 		{"0.25.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
 		{"0.24.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
+
+		// Additional tests for extra amzn2 kernels
+		{"0.24.0", "amazonlinux2", "4.14.243-185.433.amzn2"},
+		{"0.29.0", "amazonlinux2", "4.14.243-185.433.amzn2"},
+		{"0.24.0", "amazonlinux2", "5.4.105-48.177.amzn2"},
+		{"0.29.0", "amazonlinux2", "5.4.105-48.177.amzn2"},
 	}
 
 	cli := docker.MustClient()

--- a/pkg/operatingsystem/amazonlinux2/operating-system.go
+++ b/pkg/operatingsystem/amazonlinux2/operating-system.go
@@ -1,6 +1,7 @@
 package amazonlinux2
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -33,11 +34,16 @@ func (s *AmazonLinux2) GetName() string {
 
 // GetKernelPackageNames implements operatingsystem.OperatingSystem.GetKernelPackageNames for the amazonlinux2.
 func (s *AmazonLinux2) GetKernelPackageNames() ([]string, error) {
+	yumDownloaderImage, err := BuildYumDownloader(s.dockerClient)
+	if err != nil {
+		return nil, fmt.Errorf("could not build falco-driver-loader: %w", err)
+	}
+
 	out, err := s.dockerClient.Run(
 		&docker.RunOpts{
-			Image:      "docker.io/library/amazonlinux:2",
+			Image:      yumDownloaderImage,
 			Entrypoint: []string{"bash"},
-			Cmd:        []string{"-c", "yum --showduplicates list kernel-devel | tail -n+3 | awk '{ print $2 }'"},
+			Cmd:        []string{"-c", "yum --showduplicates list kernel-devel | tail -n+3 | awk '{ print $2 }' | sort -uV"},
 		},
 	)
 	if err != nil {

--- a/pkg/operatingsystem/amazonlinux2/yum-downloader.go
+++ b/pkg/operatingsystem/amazonlinux2/yum-downloader.go
@@ -6,9 +6,19 @@ import (
 	"github.com/thought-machine/falco-probes/pkg/docker"
 )
 
-// YumDownloaderDockerfile represents the contents of a Dockerfile to build the yumdownloader image which downloads RPM packages from AmazonLinux 2's repositories.
+// YumDownloaderDockerfile represents the contents of a Dockerfile to build the yumdownloader image which
+// downloads RPM packages from AmazonLinux 2's repositories. We enable additional kernels available
+// via amazon-linux-extras (when we know they will compile).
 const YumDownloaderDockerfile = `FROM amazonlinux:2
-RUN yum install -y yum-utils
+RUN yum install -y yum-utils 
+RUN export REPOS="kernel-ng kernel-5.4" \
+	&& for r in $REPOS; do \
+		amazon-linux-extras enable $r && \
+		# disable to allow us to obtain repositories which overlap.
+		amazon-linux-extras disable $r; \
+	done \
+	# enable all repositories.
+	&& sed -i 's/enabled = 0/enabled = 1/g' /etc/yum.repos.d/amzn2-extras.repo
 `
 
 // YumDownloaderRepository is the repository to build the yumdownloader image under.


### PR DESCRIPTION
While gcc issues with 5.10 persist, we can still support `kernel-ng` and `kernel-5.4`.