### PR TITLE
remove amzn2 kernel-ng

### DIFF
--- a/pkg/operatingsystem/amazonlinux2/yum-downloader.go
+++ b/pkg/operatingsystem/amazonlinux2/yum-downloader.go
@@ -11,7 +11,7 @@ import (
 // via amazon-linux-extras (when we know they will compile).
 const YumDownloaderDockerfile = `FROM amazonlinux:2
 RUN yum install -y yum-utils 
-RUN export REPOS="kernel-ng kernel-5.4" \
+RUN export REPOS="kernel-5.4" \
 	&& for r in $REPOS; do \
 		amazon-linux-extras enable $r && \
 		# disable to allow us to obtain repositories which overlap.


### PR DESCRIPTION
kernel-ng does include 5.10 releases which are currently not supported. Fixes build failures from #42 by excluding kernel-ng from hardcoded list of extra topics to install.