### PR TITLE
Skip previously compiled probes

### DIFF
--- a/build/github/build-and-publish-probes-for-operating-system/BUILD
+++ b/build/github/build-and-publish-probes-for-operating-system/BUILD
@@ -8,6 +8,7 @@ go_binary(
         "//pkg/falcodriverbuilder",
         "//pkg/operatingsystem",
         "//pkg/operatingsystem/resolver",
+        "//pkg/releasenotes",
         "//pkg/repository",
         "//pkg/repository/ghreleases",
     ],

--- a/build/github/build-and-publish-probes-for-operating-system/main.go
+++ b/build/github/build-and-publish-probes-for-operating-system/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/thought-machine/falco-probes/pkg/falcodriverbuilder"
 	"github.com/thought-machine/falco-probes/pkg/operatingsystem"
 	"github.com/thought-machine/falco-probes/pkg/operatingsystem/resolver"
+	"github.com/thought-machine/falco-probes/pkg/releasenotes"
 	"github.com/thought-machine/falco-probes/pkg/repository"
 	"github.com/thought-machine/falco-probes/pkg/repository/ghreleases"
 )
@@ -73,6 +74,17 @@ func main() {
 	log.Info().
 		Int("amount", len(kernelPackageNames)).
 		Msg("Retrieving kernel packages")
+
+	log.Info().Msg("Getting list of previously compiled probes from release notes")
+	if releases, err := ghReleases.GetReleases(); err != nil {
+		log.Warn().Err(err).Msg("could not get release notes. unable to skip previously compiled probes")
+	} else {
+		var releasedProbes releasenotes.ReleasedProbes
+		for _, r := range releases {
+			releasedProbes = append(releasedProbes, releasenotes.ParseProbesFromReleaseNotes(r)...)
+		}
+		kernelPackageNames = releasedProbes.ListKernelPackagesToCompile(kernelPackageNames, len(releases))
+	}
 
 	parallelFns := []func() error{}
 	for _, kernelPackageName := range kernelPackageNames {

--- a/build/github/build-and-publish-probes-for-operating-system/main.go
+++ b/build/github/build-and-publish-probes-for-operating-system/main.go
@@ -72,7 +72,7 @@ func main() {
 	}
 
 	log.Info().
-		Int("amount", len(kernelPackageNames)).
+		Int("total_kernel_packages", len(kernelPackageNames)).
 		Msg("Retrieving kernel packages")
 
 	log.Info().Msg("Getting list of previously compiled probes from release notes")
@@ -84,6 +84,10 @@ func main() {
 			releasedProbes = append(releasedProbes, releasenotes.ParseProbesFromReleaseNotes(r)...)
 		}
 		kernelPackageNames = releasedProbes.ListKernelPackagesToCompile(kernelPackageNames, len(releases))
+
+		log.Info().
+			Int("kernel_packages_to_compile", len(kernelPackageNames)).
+			Msg("ignoring previously compiled kernel packages")
 	}
 
 	parallelFns := []func() error{}

--- a/pkg/releasenotes/BUILD
+++ b/pkg/releasenotes/BUILD
@@ -5,7 +5,10 @@ go_library(
         "releasenotes.go",
         "tmpl.go",
     ],
-    visibility = ["//cmd/..."],
+    visibility = [
+        "//build/...",
+        "//cmd/...",
+    ],
     deps = [
         "//third_party/go:google_github",
     ],

--- a/pkg/releasenotes/releasedprobe.go
+++ b/pkg/releasenotes/releasedprobe.go
@@ -25,7 +25,7 @@ func ReleasedProbeFromMarkdownRow(s string) ReleasedProbe {
 
 	s = s[1 : len(s)-1] // remove preceding and trailing |
 	split := strings.Split(s, "|")
-	if len(split) != 2 {
+	if len(split) != 2 || split[0] == strings.Repeat("-", len(split[0])) || split[0] == " Kernel Package " {
 		return ReleasedProbe{}
 	}
 

--- a/pkg/releasenotes/releasenotes.go
+++ b/pkg/releasenotes/releasenotes.go
@@ -16,6 +16,43 @@ type ReleaseEditor interface {
 	EditReleaseNotesByReleaseID(ctx context.Context, releaseID int64, body string) error
 }
 
+// ParseProbesFromReleaseNotes converts the markdown table from the body of the release into a list of probes
+func ParseProbesFromReleaseNotes(release *github.RepositoryRelease) ReleasedProbes {
+	body := release.GetBody()
+	probes := ReleasedProbes{}
+
+	for _, line := range strings.Split(body, "\n") {
+		p := ReleasedProbeFromMarkdownRow(line)
+
+		if p.KernelPackage != "" {
+			probes = append(probes, p)
+		}
+	}
+
+	return probes
+}
+
+// ListKernelPackagesToCompile cross-references the list of released probes against the provided kernel
+// package names, returning a list of all the kernels that have not been released for _all_ Falco versions.
+func (rps ReleasedProbes) ListKernelPackagesToCompile(kernelPackageNames []string, numReleases int) []string {
+	toCompile := kernelPackageNames[:0]
+	for _, kpn := range kernelPackageNames {
+		numProbesMissing := numReleases
+
+		for _, rp := range rps {
+			if rp.KernelPackage == kpn {
+				numProbesMissing--
+			}
+		}
+
+		if numProbesMissing > 0 {
+			toCompile = append(toCompile, kpn)
+		}
+	}
+
+	return toCompile
+}
+
 // SetReleaseNotes updates the provided releases, using custom templating logic, via the github API
 func SetReleaseNotes(ctx context.Context, releases []*github.RepositoryRelease, re ReleaseEditor) error {
 	for _, r := range releases {

--- a/pkg/releasenotes/releasenotes_test.go
+++ b/pkg/releasenotes/releasenotes_test.go
@@ -70,7 +70,7 @@ func createStubReleases(probeByRelease ...[]string) []*github.RepositoryRelease 
 	return releases
 }
 
-func TestFilterPackages(t *testing.T) {
+func TestListKernelPackagesToCompile(t *testing.T) {
 	probes := releasenotes.ReleasedProbes{
 		{KernelPackage: "kp1"},
 		{KernelPackage: "kp1"},


### PR DESCRIPTION
Building off from #33 , we can now parse our release notes to see which probes have previously been compiled _for all driver versions_, and skip them. 