### PR TITLE
add Falco 0.30 (new driver) support

### DIFF
--- a/build/github/build-and-publish-probes-for-operating-system/main.go
+++ b/build/github/build-and-publish-probes-for-operating-system/main.go
@@ -24,6 +24,7 @@ var FalcoVersionNames = []string{
 	"0.26.0", // falco-driver-version: 2aa88dcf6243982697811df4c1b484bcbe9488a2
 	"0.28.1", // falco-driver-version: 5c0b863ddade7a45568c0ac97d037422c9efb750
 	"0.29.1", // falco-driver-version: 17f5df52a7d9ed6bb12d3b1768460def8439936d
+	"0.30.0", // falco-driver-version: 3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4
 }
 
 type falcoVersion struct {

--- a/pkg/falcodriverbuilder/falco-driver-builder.Dockerfile
+++ b/pkg/falcodriverbuilder/falco-driver-builder.Dockerfile
@@ -6,12 +6,12 @@ ENV FALCO_DRIVER_LOADER_PATH="/usr/bin/falco-driver-loader"
 SHELL ["/bin/bash", "-c"]
 
 RUN set -Eeuxo pipefail; \
-    # Determine DRIVERS_REPO, DRIVER_VERSION, DRIVER_NAME from existing falco-driver-loader to persist them in the 0.28.1 falco-driver-loader script.
+    # Determine DRIVERS_REPO, DRIVER_VERSION, DRIVER_NAME from existing falco-driver-loader to persist them in the 0.30.0 falco-driver-loader script.
     export DRIVERS_REPO=$(grep ^DRIVERS_REPO "${FALCO_DRIVER_LOADER_PATH}" | cut -f2 -d\") && \
     export DRIVER_VERSION=$(grep ^DRIVER_VERSION "${FALCO_DRIVER_LOADER_PATH}" | cut -f2 -d\") && \
     export DRIVER_NAME=$(grep ^DRIVER_NAME "${FALCO_DRIVER_LOADER_PATH}" | cut -f2 -d\") && \
-    # Use falco-driver-loader from 0.28.1 (the patches below work with that script.)
-    curl -L https://raw.githubusercontent.com/falcosecurity/falco/0.28.1/scripts/falco-driver-loader \
+    # Use falco-driver-loader from 0.30.0 (the patches below work with that script.)
+    curl -L https://raw.githubusercontent.com/falcosecurity/falco/0.30.0/scripts/falco-driver-loader \
     -o /usr/bin/falco-driver-loader && chmod +x /usr/bin/falco-driver-loader && \
     # Set DRIVERS_REPO to match existing falco-driver-loader script.
     sed -i '/^\s*DRIVERS_REPO=/d' "${FALCO_DRIVER_LOADER_PATH}" && \


### PR DESCRIPTION
This PR adds support for the newest version of Falco (0.30.0) which uses a new Falco Driver Version (`3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4`).

I've also updated our `falco-driver-loader` script to include https://github.com/falcosecurity/falco/pull/1716 which was included in 0.30.0.