### PR TITLE
allow arbitrary triggering of publish

### DIFF
--- a/.github/workflows/build-and-publish-probes.yaml
+++ b/.github/workflows/build-and-publish-probes.yaml
@@ -5,6 +5,7 @@ on:
       - master
   schedule:
     - cron:  '0 0 * * *' # Runs at 00:00 UTC every day.
+  workflow_dispatch: {}
 jobs:
   generate-jobs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds support for arbitrary triggering of the Publish workflow so that we can trigger it through the GitHub Actions UI. This is useful when GitHub has disabled workflows due to inactivity.