### PR TITLE
Fix kernel config download for older COS versions

### DIFF
--- a/pkg/operatingsystem/cos/BUILD
+++ b/pkg/operatingsystem/cos/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//pkg/...",
     ],
     deps = [
+        "//internal/logging",
         "//pkg/docker",
         "//pkg/operatingsystem",
         "//pkg/operatingsystem/cos/buildid",

--- a/pkg/operatingsystem/cos/kernel-package_test.go
+++ b/pkg/operatingsystem/cos/kernel-package_test.go
@@ -10,17 +10,21 @@ import (
 	"github.com/thought-machine/falco-probes/pkg/operatingsystem/cos"
 )
 
+// Tests that the kernel config is downloaded from the fallback filename: x86_64_defconfig.
+// See https://cos.googlesource.com/third_party/kernel/+/cb1d3f28467d33c1165181e8ddd2982311fd4687/arch/x86/configs/
+// vs. https://cos.googlesource.com/third_party/kernel/+/c19d150c6bd658510ec786390aec80ad476c7578/arch/x86/configs/
 func TestGetKernelConfiguration(t *testing.T) {
 	cli := docker.MustClient()
 
-	kp, err := cos.NewKernelPackage(cli, "cos-101-17162-40-34")
+	// TODO: mock the http calls.
+	kp, err := cos.NewKernelPackage(cli, "cos-89-16108-403-11")
 	require.NoError(t, err)
 
 	out, err := cli.Run(
 		&docker.RunOpts{
 			Image:      "docker.io/library/busybox:latest",
-			Entrypoint: []string{"ls"},
-			Cmd:        []string{"-l", "/lib/modules/"},
+			Entrypoint: []string{"/bin/sh"},
+			Cmd:        []string{"-c", "ls /lib/modules && cat /lib/modules/*/config"},
 			Volumes: map[operatingsystem.Volume]string{
 				kp.KernelConfiguration: "/lib/modules/",
 			},
@@ -28,13 +32,15 @@ func TestGetKernelConfiguration(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	assert.Contains(t, out, "5.15.65")
+	assert.Contains(t, out, "5.4.104")
+	assert.Contains(t, out, "CONFIG_")
 }
 
 // Tests that /usr/src/kernels is present but empty as Falco doesn't require the Google COS sources.
 func TestGetKernelSources(t *testing.T) {
 	cli := docker.MustClient()
 
+	// TODO: mock the http calls.
 	kp, err := cos.NewKernelPackage(cli, "cos-101-17162-40-34")
 	require.NoError(t, err)
 


### PR DESCRIPTION
In older versions of COS, the config is found at `x86_64_defconfig`. This commit changes to kernel config download to attempt retrieval of the `lakitu_defconfig` file and if that produces a 404 fallback to the older file.

Of the [errors in the build action](https://github.com/thought-machine/falco-probes/actions/runs/3575728298/jobs/6012651224) this should fix errors like:

```
3:58PM ERR error encountered error="could not get kernel package 'cos-89-16108-403-11': could not get 2XX response for kernel config for build id 16108.403.11 (kernel commit c19d150c6bd658510ec786390aec80ad476c7578): 404 Not Found"
``` 

and may fix errors like:

```
3:58PM ERR error encountered error="could not build probe for 'cos-97-16919-103-51': could not build falco probe: non-zero exit-code (1) for: \n* Setting up /usr/src links from host\nFALCO_VERSION: 0.24.0\nDRIVER_NAME: falco\nDRIVER_VERSION: 85c88952b018fdbce2464222c3303229f5bfcfad\n* Running falco-driver-loader for: falco version=0.24.0, driver version=85c88952b018fdbce2464222c3303229f5bfcfad, arch=x86_64, kernel release=5.10.133, kernel version=1\n* Running falco-driver-loader with: driver=bpf, compile=yes, download=no\n* Mounting debugfs\nmount: /sys/kernel/debug: permission denied.\n* Filename 'falco_cos_5.10.133_1.o' is composed of:\n - driver name: falco\n - target identifier: cos\n - kernel release: 5.10.133\n - kernel version: 1\n* COS detected (build 16919.103.51), using COS kernel headers\nCannot find kernel config\n"
```

although will investigate further on the latter if not.