### PR TITLE
Fix COS kernel config location and build errors

### DIFF
--- a/docs/BUILD_DESIGN_assets/build-amazonlinux2-ebpf-probe.sh
+++ b/docs/BUILD_DESIGN_assets/build-amazonlinux2-ebpf-probe.sh
@@ -84,7 +84,7 @@ docker run --rm \
     --env UNAME_M="$UNAME_M" \
     --env HOST_ROOT="/host" \
     --volume "${usr_src_volume}":"/host/usr/src/" \
-    --volume "${lib_modules_volume}":"/lib/modules/" \
+    --volume "${lib_modules_volume}":"/host/lib/modules/" \
     --volume "${etc_volume}":"/host/etc/" \
     "${FALCO_DRIVER_BUILDER_IMAGE}"
 

--- a/docs/BUILD_DESIGN_assets/build-cos-ebpf-probe.sh
+++ b/docs/BUILD_DESIGN_assets/build-cos-ebpf-probe.sh
@@ -114,9 +114,8 @@ docker run --rm \
     --env UNAME_R="${UNAME_R}" \
     --env UNAME_M="${UNAME_M}" \
     --env BUILD_ID="${BUILD_ID}" \
-    --env HOST_ROOT="/host" \
     --volume "${usr_src_volume}":"/host/usr/src/" \
-    --volume "${lib_modules_volume}":"/lib/modules/" \
+    --volume "${lib_modules_volume}":"/host/lib/modules/" \
     --volume "${etc_volume}":"/host/etc/" \
     "${FALCO_DRIVER_BUILDER_IMAGE}"
 

--- a/docs/BUILD_DESIGN_assets/falco-driver-builder.Dockerfile
+++ b/docs/BUILD_DESIGN_assets/falco-driver-builder.Dockerfile
@@ -27,9 +27,15 @@ RUN set -Eeuxo pipefail; \
     sed -i 's/uname -m/echo "${UNAME_M:-$(uname -m)}"/g' "${FALCO_DRIVER_LOADER_PATH}" && \
     echo "Done!"
 
+# Build falco probes in a recent version of Ubuntu to ensure we have up-to-date tooling
+# containing required symbols (e.g. GLIBC_<RECENT_VERSION>).
 FROM docker.io/ubuntu:${UBUNTU_VERSION}
 
 ENV FALCO_DRIVER_LOADER_PATH="/usr/bin/falco-driver-loader"
+
+# Set up the Falco enviromental variables.
+ENV HOST_ROOT /host
+ENV HOME /root
 
 SHELL ["/bin/bash", "-c"]
 
@@ -43,6 +49,10 @@ RUN set -Eeuxo pipefail; \
       llvm \
     && \
     rm -rf /var/lib/apt/lists/*
+
+# Set up the Falco symlinks.
+RUN rm -df /lib/modules \
+	&& ln -s $HOST_ROOT/lib/modules /lib/modules
 
 # Copy in entrypoint, falco source and falco-driver-loader script
 COPY --from=falco-driver-loader "/docker-entrypoint.sh" "/docker-entrypoint.sh"

--- a/pkg/falcodriverbuilder/build-ebpf-probe_test.go
+++ b/pkg/falcodriverbuilder/build-ebpf-probe_test.go
@@ -11,28 +11,38 @@ import (
 	"github.com/thought-machine/falco-probes/pkg/operatingsystem/resolver"
 )
 
+// Only test a sample of versions as otherwise Github Actions times out.
 func TestBuildEBPFProbe(t *testing.T) {
 	var tests = []struct {
 		falcoVersion        string
 		operatingSystemName string
 		kernelPackageName   string
 	}{
-		{"0.29.1", "amazonlinux2", "4.14.200-155.322.amzn2"},
+	    // Amazon Linux 2
+		{"0.33.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
+		{"0.31.1", "amazonlinux2", "4.14.200-155.322.amzn2"},
 		{"0.29.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
-		{"0.28.1", "amazonlinux2", "4.14.200-155.322.amzn2"},
-		{"0.28.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
-		{"0.27.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
 		{"0.26.2", "amazonlinux2", "4.14.200-155.322.amzn2"},
-		{"0.26.1", "amazonlinux2", "4.14.200-155.322.amzn2"},
-		{"0.26.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
-		{"0.25.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
 		{"0.24.0", "amazonlinux2", "4.14.200-155.322.amzn2"},
 
 		// Additional tests for extra amzn2 kernels
 		{"0.24.0", "amazonlinux2", "4.14.243-185.433.amzn2"},
-		{"0.29.0", "amazonlinux2", "4.14.243-185.433.amzn2"},
+		{"0.33.0", "amazonlinux2", "4.14.243-185.433.amzn2"},
 		{"0.24.0", "amazonlinux2", "5.4.105-48.177.amzn2"},
-		{"0.29.0", "amazonlinux2", "5.4.105-48.177.amzn2"},
+		{"0.33.0", "amazonlinux2", "5.4.105-48.177.amzn2"},
+
+		// Google COS
+		{"0.33.0", "cos", "cos-101-17162-40-34"},
+		{"0.31.1", "cos", "cos-101-17162-40-34"},
+		{"0.29.0", "cos", "cos-101-17162-40-34"},
+		{"0.26.2", "cos", "cos-101-17162-40-34"},
+		{"0.24.0", "cos", "cos-101-17162-40-34"},
+
+		// Additional tests for extra cos versions
+		{"0.24.0", "cos", "cos-97-16919-0-3"},
+		{"0.33.0", "cos", "cos-97-16919-0-3"},
+		{"0.24.0", "cos", "cos-93-16623-0-5"},
+		{"0.33.0", "cos", "cos-93-16623-0-5"},
 	}
 
 	cli := docker.MustClient()

--- a/pkg/falcodriverbuilder/falco-driver-builder.Dockerfile
+++ b/pkg/falcodriverbuilder/falco-driver-builder.Dockerfile
@@ -1,5 +1,7 @@
 ARG FALCO_VERSION
-FROM "docker.io/falcosecurity/falco-driver-loader:${FALCO_VERSION}"
+ARG UBUNTU_VERSION
+
+FROM "docker.io/falcosecurity/falco-driver-loader:${FALCO_VERSION}" as falco-driver-loader
 
 ENV FALCO_DRIVER_LOADER_PATH="/usr/bin/falco-driver-loader"
 
@@ -13,6 +15,15 @@ RUN set -Eeuxo pipefail; \
     # Use falco-driver-loader from 0.33.0 (the patches below work with that script.)
     curl -L https://raw.githubusercontent.com/falcosecurity/falco/0.33.0/scripts/falco-driver-loader \
     -o /usr/bin/falco-driver-loader && chmod +x /usr/bin/falco-driver-loader && \
+    # Add KBUILD_MODNAME if it doesn't already exist.
+    { grep -q "KBUILD_MODNAME" "/usr/src/falco-${DRIVER_VERSION}/driver_config.h" || \
+        printf '\n#ifndef KBUILD_MODNAME\n#define KBUILD_MODNAME "falco"\n#endif' >> \
+            "/usr/src/falco-${DRIVER_VERSION}/driver_config.h"; \
+    } && \
+    # Add an always-y rule in Falco's bpf Makefile for newer kernels if it doesn't already exist.
+    { grep -q "always-y" "/usr/src/falco-${DRIVER_VERSION}/bpf/Makefile" || \
+        sed -i -e '/^always .*/a\' -e 'always-y += probe.o' "/usr/src/falco-${DRIVER_VERSION}/bpf/Makefile"; \
+    } && \
     # Set DRIVERS_REPO to match existing falco-driver-loader script.
     sed -i '/^\s*DRIVERS_REPO=/d' "${FALCO_DRIVER_LOADER_PATH}" && \
     sed -i "2 i DRIVERS_REPO=\"${DRIVERS_REPO}\"" "${FALCO_DRIVER_LOADER_PATH}" && \
@@ -34,10 +45,49 @@ RUN set -Eeuxo pipefail; \
     # Enable compilation of eBPF driver.
     sed -i 's/ENABLE_COMPILE=.*/ENABLE_COMPILE="yes"/g' "${FALCO_DRIVER_LOADER_PATH}" && \
     sed -i 's/DRIVER=.*/DRIVER="bpf"/g' "${FALCO_DRIVER_LOADER_PATH}" && \
+    # Echo the KERNEL_RELEASE, KERNEL_VERSION and ARCH
+    sed -i -e '/^KERNEL_RELEASE=.*/a\' -e 'echo "KERNEL_RELEASE: $KERNEL_RELEASE"' "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i -e '/^KERNEL_VERSION=.*/a\' -e 'echo "KERNEL_VERSION: $KERNEL_VERSION"' "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i -e '/^ARCH=.*/a\' -e 'echo "ARCH: $ARCH"' "${FALCO_DRIVER_LOADER_PATH}" && \
     # Set the KERNELDIR from the KERNEL_RELEASE. This is used in kernel Makefiles.
-    sed -i -e '/^KERNEL_RELEASE=.*/a\' -e 'export KERNELDIR="/lib/modules/$KERNEL_RELEASE/build"' "${FALCO_DRIVER_LOADER_PATH}" && \
+    sed -i -e '/^KERNEL_RELEASE=.*/a\' -e 'export KERNELDIR="/host/usr/src/kernels/$KERNEL_RELEASE"' "${FALCO_DRIVER_LOADER_PATH}" && \
     # Allow setting the outputs of `uname` via UNAME_* environment variables.
     sed -i 's/uname -r/echo "${UNAME_R}"/g' "${FALCO_DRIVER_LOADER_PATH}" && \
     sed -i 's/uname -v/echo "${UNAME_V}"/g' "${FALCO_DRIVER_LOADER_PATH}" && \
     sed -i 's/uname -m/echo "${UNAME_M}"/g' "${FALCO_DRIVER_LOADER_PATH}" && \
     echo "Done!"
+
+# Build falco probes in a recent version of Ubuntu to ensure we have up-to-date tooling
+# containing required symbols (e.g. GLIBC_<RECENT_VERSION>).
+FROM docker.io/ubuntu:${UBUNTU_VERSION}
+
+ENV FALCO_DRIVER_LOADER_PATH="/usr/bin/falco-driver-loader"
+
+# Set up the Falco enviromental variables.
+ENV HOST_ROOT /host
+ENV HOME /root
+
+SHELL ["/bin/bash", "-c"]
+
+# Install dev tools.
+RUN set -Eeuxo pipefail; \
+    apt-get update && apt-get install -y \
+      build-essential \
+      clang \
+      curl \
+      git \
+      libelf-dev \
+      llvm \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set up the Falco symlinks.
+RUN rm -df /lib/modules \
+	&& ln -s $HOST_ROOT/lib/modules /lib/modules
+
+# Copy in entrypoint, falco source and falco-driver-loader script
+COPY --from=falco-driver-loader "/docker-entrypoint.sh" "/docker-entrypoint.sh"
+COPY --from=falco-driver-loader "/usr/src" "/usr/src"
+COPY --from=falco-driver-loader "${FALCO_DRIVER_LOADER_PATH}" "${FALCO_DRIVER_LOADER_PATH}"
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/pkg/falcodriverbuilder/falcodriverbuilder.go
+++ b/pkg/falcodriverbuilder/falcodriverbuilder.go
@@ -24,6 +24,8 @@ const (
 	FalcoDriverBuilderRepository = "docker.io/thoughtmachine/falco-driver-builder"
 	// BuiltFalcoProbesDir references the directory where the falco-driver-builder image outputs built probes to.
 	BuiltFalcoProbesDir = "/root/.falco/"
+	// UbuntuVersion is the version of Ubuntu we build the probes in.
+	UbuntuVersion = "22.04"
 )
 
 var (
@@ -41,6 +43,7 @@ func BuildImage(
 		Dockerfile: FalcoDriverBuilderDockerfile,
 		BuildArgs: map[string]*string{
 			"FALCO_VERSION": docker.StrPtr(falcoVersion),
+			"UBUNTU_VERSION": docker.StrPtr(UbuntuVersion),
 		},
 		Tags: []string{imageFQN},
 	})

--- a/pkg/operatingsystem/cos/buildid/validator_test.go
+++ b/pkg/operatingsystem/cos/buildid/validator_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestFilterInvalid(t *testing.T) {
 	// See https://cos.googlesource.com/cos/manifest-snapshots/+log/refs/heads/release-R101/
-	testBuildIDs := []string{"17162.40.35", "17162.40.34", "17162.40.25", "17162.40.24"}
+	testBuildIDs := []string{"17162.40.35", "17162.40.34", "17162.40.25", "17162.40.24", "17154.0.0"}
 	// See https://cloud.google.com/container-optimized-os/docs/release-notes/m101
 	expectedBuildIDs := []string{"17162.40.34", "17162.40.25"}
 

--- a/pkg/operatingsystem/cos/kernel-package.go
+++ b/pkg/operatingsystem/cos/kernel-package.go
@@ -77,7 +77,7 @@ func addSourcesAndConfiguration(dockerClient *docker.Client, kp *operatingsystem
 		return err
 	}
 
-	commandTemplate := "mkdir -p /usr/src/kernels && mkdir -p '/lib/modules/%s+'"
+	commandTemplate := "mkdir -p /usr/src/kernels && mkdir -p '/lib/modules/%s'"
 
 	kp.KernelConfiguration = dockerClient.MustCreateVolume()
 	kp.KernelSources = dockerClient.MustCreateVolume()
@@ -96,7 +96,7 @@ func addSourcesAndConfiguration(dockerClient *docker.Client, kp *operatingsystem
 		return err
 	}
 
-	err = dockerClient.WriteFileToVolume(kp.KernelConfiguration, "/lib/modules/", fmt.Sprintf("/lib/modules/%s+/config", kp.KernelRelease), kernelConfig)
+	err = dockerClient.WriteFileToVolume(kp.KernelConfiguration, "/lib/modules/", fmt.Sprintf("/lib/modules/%s/config", kp.KernelRelease), kernelConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Falco-driver-builder expects the kernel to be in [one of several places](https://github.com/falcosecurity/falco/blob/master/scripts/falco-driver-loader#L69-L94) of which we use `/lib/modules/<kernel_release>/config`. This commit fixes a bug where an extraneous `+` was added to the `/lib/modules/<kernel_release>` folder (resulting in `/lib/modules/<kernel_release>+/config`), meaning falco-driver-loader was unable to find the config.