### PR TITLE
Drop minimum COS milestone to 85 for clusters being upgraded

### DIFF
--- a/pkg/operatingsystem/cos/git-reader.go
+++ b/pkg/operatingsystem/cos/git-reader.go
@@ -12,7 +12,8 @@ import (
 const (
 	// MilestoneMin is the lowest active milestone. Lower value milestones are not built. See
 	// https://cloud.google.com/container-optimized-os/docs/concepts/versioning.
-	MilestoneMin = 89
+	// Set to 85 (despite deprecation to cover versions that are being upgraded).
+	MilestoneMin = 85
 
 	milestonePrefix = "origin/release-R"
 	buildIDFormat   = "%d.%d.%d"


### PR DESCRIPTION
Testing build locally attempts to build e.g. `5.4.129`:

```
1:51PM INF Got kernel_package kernel_package=cos-85-13310-1308-19 probe_name=falco_cos_5.4.129_1.o
1:51PM INF Checking whether probe is built & published driver=85c88952b018fdbce2464222c3303229f5bfcfad probe_name=falco_cos_5.4.129_1.o
1:51PM INF Got kernel_package kernel_package=cos-93-16623-171-19 probe_name=falco_cos_5.10.109_1.o
1:51PM INF Checking whether probe is built & published driver=85c88952b018fdbce2464222c3303229f5bfcfad probe_name=falco_cos_5.10.109_1.o
1:51PM ERR  error="could not get release: could not list releases: could not list releases: GET https://api.github.com/repos/thought-machine/falco-probes/releases?per_page=100: 401 Bad credentials []"
1:51PM INF Not found, probe will now be built driver=85c88952b018fdbce2464222c3303229f5bfcfad probe_name=falco_cos_5.4.129_1.o
```