### PR TITLE
Add + to COS probes filename...

### DIFF
--- a/pkg/operatingsystem/cos/operating-system_test.go
+++ b/pkg/operatingsystem/cos/operating-system_test.go
@@ -29,7 +29,7 @@ func TestGetKernelPackageByName(t *testing.T) {
 	res, err := os.GetKernelPackageByName("cos-101-17162-40-34")
 	assert.NoError(t, err)
 
-	assert.Equal(t, "5.15.65", res.KernelRelease)
+	assert.Equal(t, "5.15.65+", res.KernelRelease)
 	assert.Equal(t, "#1 SMP Thu Nov 10 10:13:28 UTC 2022", res.KernelVersion)
 	assert.Equal(t, "x86_64", res.KernelMachine)
 	assert.Contains(t, res.OSRelease, "NAME=\"Container-Optimized OS\"")


### PR DESCRIPTION
... as the kernel release includes one and falco expects it when looking for the filename:

```
* Filename 'falco_cos_5.4.144+_1.o' is composed of:
```