### PR TITLE
Bump COS to exclude deprecated releases

### DIFF
--- a/pkg/operatingsystem/cos/git-reader.go
+++ b/pkg/operatingsystem/cos/git-reader.go
@@ -12,8 +12,7 @@ import (
 const (
 	// MilestoneMin is the lowest active milestone. Lower value milestones are not built. See
 	// https://cloud.google.com/container-optimized-os/docs/concepts/versioning.
-	// Set to 85 (despite deprecation to cover versions that are being upgraded).
-	MilestoneMin = 85
+	MilestoneMin = 93
 
 	milestonePrefix = "origin/release-R"
 	buildIDFormat   = "%d.%d.%d"


### PR DESCRIPTION
This is also needed to reduce the number of images we are building and [avoid rate limits which are affecting the build](https://github.com/thought-machine/falco-probes/actions/runs/6328271290/job/17186099118).