### PR TITLE
Enable publishing of 5.10 probes

### DIFF
--- a/pkg/operatingsystem/amazonlinux2/kernel-package.go
+++ b/pkg/operatingsystem/amazonlinux2/kernel-package.go
@@ -119,7 +119,7 @@ func addKernelReleaseAndVersionAndMachine(dockerClient *docker.Client, kp *opera
 	}
 	kp.KernelMachine = kernelMachine
 
-	kp.KernelRelease = kp.Name + "." + kp.kernelMachine
+	kp.KernelRelease = kp.Name + "." + kp.KernelMachine
 
 	return nil
 }

--- a/pkg/operatingsystem/amazonlinux2/kernel-package.go
+++ b/pkg/operatingsystem/amazonlinux2/kernel-package.go
@@ -107,12 +107,6 @@ func addKernelReleaseAndVersionAndMachine(dockerClient *docker.Client, kp *opera
 		return err
 	}
 
-	kernelRelease, err := getKernelRelease(dockerClient, kp.KernelSources, kernelSrcPath)
-	if err != nil {
-		return err
-	}
-	kp.KernelRelease = kernelRelease
-
 	kernelVersion, err := getKernelVersion(dockerClient, kp.KernelSources, kernelSrcPath)
 	if err != nil {
 		return err
@@ -124,6 +118,8 @@ func addKernelReleaseAndVersionAndMachine(dockerClient *docker.Client, kp *opera
 		return err
 	}
 	kp.KernelMachine = kernelMachine
+
+	kp.KernelRelease = kp.Name + "." + kp.kernelMachine
 
 	return nil
 }

--- a/pkg/operatingsystem/amazonlinux2/yum-downloader.go
+++ b/pkg/operatingsystem/amazonlinux2/yum-downloader.go
@@ -11,7 +11,7 @@ import (
 // via amazon-linux-extras (when we know they will compile).
 const YumDownloaderDockerfile = `FROM amazonlinux:2
 RUN yum install -y yum-utils 
-RUN export REPOS="kernel-5.4" \
+RUN export REPOS="kernel-5.4 kernel-5.10" \
 	&& for r in $REPOS; do \
 		amazon-linux-extras enable $r && \
 		# disable to allow us to obtain repositories which overlap.


### PR DESCRIPTION
Currently we're not publishing 5.10 probes - this PR fixes the compile error for 5.10 probes by deriving the KernelRelease from the kernel package name and KernelMachine (since we already have both of these) instead of using make, and then adds 5.10 to the yum-downloader extra repos.