### PR TITLE
Add log line to determine which Kernel releases we are processing

### DIFF
--- a/pkg/operatingsystem/BUILD
+++ b/pkg/operatingsystem/BUILD
@@ -4,6 +4,9 @@ go_library(
         "kernel-package.go",
         "operating-system.go",
     ],
+    deps = [
+        "//internal/logging",
+    ],
     visibility = [
         "//build/...",
         "//cmd/...",

--- a/pkg/operatingsystem/kernel-package.go
+++ b/pkg/operatingsystem/kernel-package.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/thought-machine/falco-probes/internal/logging"
 )
 
 // KernelPackage represents the required inputs for build a Falco Driver for a Kernel Package.
@@ -26,7 +28,10 @@ type KernelPackage struct {
 	KernelSources Volume
 }
 
-var kernelVersionRe = regexp.MustCompile(`^#(\d+)`)
+var (
+	kernelVersionRe = regexp.MustCompile(`^#(\d+)`)
+	log    = logging.Logger
+)
 
 // ProbeName returns the ProbeName expected by Falco.
 // interpreted from: https://github.com/falcosecurity/falco/blob/0.29.1/scripts/falco-driver-loader#L449
@@ -34,6 +39,7 @@ func (kp *KernelPackage) ProbeName() string {
 	driverName := "falco"
 	targetID := kp.OperatingSystem
 	kernelRelease := kp.KernelRelease
+	log.Info().Str("kernelRelease", kernelRelease)
 	// from: $(uname -v | sed 's/#\([[:digit:]]\+\).*/\1/')
 	// this sed command is extracting the first set of digits from the KernelVersion after the #. e.g.
 	// `#151-Ubuntu SMP Fri Jun 18 19:21:19 UTC 2021` becomes `151`.


### PR DESCRIPTION
This would be useful so we can validate whether the regex operates under correct assumptions.