### PR TITLE
Parse generated/utsversion.h to parse the Kernel Version on newer COS kernels

### DIFF
--- a/pkg/operatingsystem/cos/kernel-package.go
+++ b/pkg/operatingsystem/cos/kernel-package.go
@@ -219,11 +219,11 @@ func extractKernelDetails(buildID string, kernelHeaders io.Reader, kp *operating
 			}
 			kp.KernelRelease = components[0]
 		case tar.TypeReg:
-			// Read kernel version and machine from generated/compile.h
+			// Read kernel version and machine from generated/compile.h and generated/utsversion.h
 			if kp.KernelVersion != "" && kp.KernelMachine != "" {
 				continue
 			}
-			if !strings.Contains(header.Name, "generated/compile.h") {
+			if !(strings.Contains(header.Name, "generated/compile.h") || strings.Contains(header.Name, "generated/utsversion.h")) {
 				continue
 			}
 			scanner := bufio.NewScanner(extractedKernelHeaders)


### PR DESCRIPTION
Fixes https://github.com/thought-machine/falco-probes/issues/79

It looks like these kernel releases no longer place the `UTS_VERSION` variable in the `generated/compile.h` header file, instead favouring a dedicated file, `generated/utsversion.h`. Therefore get it from here.

This is untested but should not cause any regressions. We will know if this works because COS probes for kernel versions >= 6 will be formatted with a kernel version number, if it can be found.